### PR TITLE
Use the kube_command helper to set context in a few more places

### DIFF
--- a/lib/kitchen/driver/kubernetes.rb
+++ b/lib/kitchen/driver/kubernetes.rb
@@ -49,7 +49,11 @@ module Kitchen
       default_config :pod_template, File.expand_path('../pod.yaml.erb', __FILE__)
       default_config :rsync_command, 'rsync'
       default_config :rsync_image, 'kitchenkubernetes/rsync:3.1.2-r5'
-      default_config :rsync_rsh, "#{RbConfig.ruby} -e \"exec('kubectl', 'exec', '--stdin', '--container=rsync', ARGV[0], '--', *ARGV[1..-1])\""
+      default_config :rsync_rsh, [
+        "#{RbConfig.ruby} -e \"exec(",
+        ['exec', '--stdin', '--container=rsync'],
+        ", ARGV[0], '--', *ARGV[1..-1])\""
+      ]
 
       default_config :cache_volume do |driver|
         if driver[:cache_path]

--- a/lib/kitchen/transport/kubernetes.rb
+++ b/lib/kitchen/transport/kubernetes.rb
@@ -43,6 +43,7 @@ module Kitchen
           rsync_command: config[:rsync_command],
           rsync_rsh: config[:rsync_rsh],
           log_level: config[:log_level],
+          context: config[:context],
           logger: logger
         ).tap do |conn|
           block.call(conn) if block
@@ -63,8 +64,9 @@ module Kitchen
         # (see Base::Connection#upload)
         def upload(locals, remote)
           return if locals.empty?
+          rsh = [ options[:rsync_rsh][0], "'"+kubectl_command(options[:rsync_rsh][1]).join("','")+"'", options[:rsync_rsh][2] ].join("")
           # Use rsync over kubectl exec to send files.
-          run_command([options[:rsync_command], '--archive', '--progress', '--blocking-io', '--rsh', options[:rsync_rsh]] + (options[:log_level] == :debug ? %w{--verbose --verbose --verbose} : []) + locals + ["#{options[:pod_id]}:#{remote}"])
+          run_command([options[:rsync_command], '--archive', '--progress', '--blocking-io', '--rsh', rsh] + (options[:log_level] == :debug ? %w{--verbose --verbose --verbose} : []) + locals + ["#{options[:pod_id]}:#{remote}"])
         end
 
         # (see Base::Connection#login_command)


### PR DESCRIPTION
This fixes an issue I saw in testing the context: config option.  The config was not reaching all the commands.

I'm not sure how I like the rsync_rsh config option being an array, but its the way I figured out how to do it.  comments are welcome.

I solved it another way here: https://github.com/EMSL-MSC/kitchen-kubernetes/tree/fixup-context-config
But that completely ignored the kube_command helper