### PR TITLE
downcase podname

### DIFF
--- a/lib/kitchen/driver/kubernetes.rb
+++ b/lib/kitchen/driver/kubernetes.rb
@@ -71,7 +71,7 @@ module Kitchen
           (Etc.getlogin || 'nologin').gsub(/\W/, ''),
           Socket.gethostname.gsub(/\W/, '')[0..20],
           Array.new(8) { rand(36).to_s(36) }.join
-        ].join('-')
+        ].join('-').downcase
       end
 
       # Don't expand path on commands that don't look like a path, otherwise


### PR DESCRIPTION
Kubernetes pods cannot be named with upper case characters due to DNS-1123.
This PR certains pod name is lower cased.

```
>>>>>> ------Exception-------
>>>>>> Class: Kitchen::ActionFailed
>>>>>> Message: 1 actions failed.
>>>>>>     Failed to complete #create action: [Expected process to exit with [0], but received '1'
---- Begin output of ["kubectl", "create", "--filename", "-"] ----
STDOUT:
STDERR: The Pod "testel6-2k0ri-MBP-yop1a4w5" is invalid: metadata.name: Invalid value: "testel6-2k0ri-MBP-yop1a4w5": a DNS-1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')
---- End output of ["kubectl", "create", "--filename", "-"] ----
Ran ["kubectl", "create", "--filename", "-"] returned 1] on test-el6
>>>>>> ----------------------
>>>>>> Please see .kitchen/logs/kitchen.log for more details
>>>>>> Also try running `kitchen diagnose --all` for configuration
```